### PR TITLE
fix: handle event.location and event.description being null

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -116,7 +116,7 @@ function eventDetails(event) {
 	eDetails.appendChild(whenLabel);
 	eDetails.appendChild(when);
 
-	if (event.location != '') {
+	if (event.location) {
 		eDetails.appendChild(document.createElement('br'));
 		let whereLabel = document.createElement('strong');
 		whereLabel.appendChild(document.createTextNode('Where: '));
@@ -134,7 +134,7 @@ function eventDetails(event) {
 		eDetails.appendChild(where);
 	}
 
-	if (event.description != '') {
+	if (event.description) {
 		eDetails.appendChild(document.createElement('br'));
 		let descLabel = document.createElement('strong');
 		descLabel.appendChild(document.createTextNode('Description: '));


### PR DESCRIPTION
Prevents an error when rendering events with null locations and descriptions. This error is common with google calendar ICS links when they are set to show free / busy instead of full event details.