### PR TITLE
Only show location if event.location is not empty and not null

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -116,7 +116,7 @@ function eventDetails(event) {
 	eDetails.appendChild(whenLabel);
 	eDetails.appendChild(when);
 
-	if (event.location != '') {
+	if (event.location != '' && event.location != null) {
 		eDetails.appendChild(document.createElement('br'));
 		let whereLabel = document.createElement('strong');
 		whereLabel.appendChild(document.createTextNode('Where: '));


### PR DESCRIPTION
I tried `console.log` my `event.location` to find the cause of issue #2 and it turns out some of my events have location variables that are not empty, they are `null`.

![location_is_null](https://user-images.githubusercontent.com/15460993/95246693-21d6e900-0815-11eb-9eb0-5e9fe4740cf2.png)

Added a condition to the if-statement to make sure `event.location` is also not `null`.

Fixes #2